### PR TITLE
test: add VS Code extension e2e coverage

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,16 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { defineConfig } from '@vscode/test-cli';
+
+const workspaceFolder = path.join(os.tmpdir(), 'latex-graphics-helper-vscode-test-workspace');
+fs.mkdirSync(workspaceFolder, { recursive: true });
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
+	workspaceFolder,
+	mocha: {
+		timeout: 20000,
+	},
 });

--- a/src/test/e2e/commands.test.ts
+++ b/src/test/e2e/commands.test.ts
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import * as vscode from 'vscode';
 
 import { localeMap } from '../../locale_map';
+
 import { createPdf, createPng, createTestDirectory, deleteDirectory, readPdfPageCount, waitForFile } from './helpers';
 
 const commandIds = [

--- a/src/test/e2e/commands.test.ts
+++ b/src/test/e2e/commands.test.ts
@@ -1,0 +1,126 @@
+import * as assert from 'assert';
+
+import sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import { localeMap } from '../../locale_map';
+import { createPdf, createPng, createTestDirectory, deleteDirectory, readPdfPageCount, waitForFile } from './helpers';
+
+const commandIds = [
+    'latex-graphics-helper.cropPdf',
+    'latex-graphics-helper.splitPdf',
+    'latex-graphics-helper.mergePdf',
+    'latex-graphics-helper.convertDrawioToPdf',
+    'latex-graphics-helper.convertPdfToPng',
+    'latex-graphics-helper.convertPdfToJpeg',
+    'latex-graphics-helper.convertPdfToSvg',
+    'latex-graphics-helper.convertPngToPdf',
+    'latex-graphics-helper.convertJpegToPdf',
+    'latex-graphics-helper.convertSvgToPdf',
+];
+
+suite('VS Code command e2e Test Suite', () => {
+    suiteSetup(async () => {
+        await vscode.extensions.getExtension('naatin777.latex-graphics-helper')!.activate();
+        await vscode.workspace.getConfiguration('latex-graphics-helper').update(
+            'outputPath.splitPdf',
+            '${fileDirname}/${fileBasenameNoExtension}-${page}.pdf',
+            vscode.ConfigurationTarget.Workspace
+        );
+        await vscode.workspace.getConfiguration('latex-graphics-helper').update(
+            'outputPath.convertPngToPdf',
+            '${fileDirname}/${fileBasenameNoExtension}.pdf',
+            vscode.ConfigurationTarget.Workspace
+        );
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('should register all contributed commands', async () => {
+        const registeredCommands = await vscode.commands.getCommands(true);
+
+        for (const commandId of commandIds) {
+            assert.ok(registeredCommands.includes(commandId), `Expected command to be registered: ${commandId}`);
+        }
+    });
+
+    test('should show an error when commands are invoked without selected files', async () => {
+        const showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+
+        for (const commandId of commandIds) {
+            await vscode.commands.executeCommand(commandId);
+        }
+
+        assert.strictEqual(showErrorMessageStub.callCount, commandIds.length);
+        for (const call of showErrorMessageStub.getCalls()) {
+            assert.strictEqual(call.args[0], localeMap('noFilesSelected'));
+        }
+    });
+
+    test('should split a PDF selected from the explorer', async () => {
+        const directory = await createTestDirectory('split-pdf-command');
+
+        try {
+            const inputUri = vscode.Uri.joinPath(directory, 'source.pdf');
+            const firstOutputUri = vscode.Uri.joinPath(directory, 'source-1.pdf');
+            const secondOutputUri = vscode.Uri.joinPath(directory, 'source-2.pdf');
+
+            await createPdf(inputUri, 2);
+
+            await vscode.commands.executeCommand('latex-graphics-helper.splitPdf', inputUri, [inputUri]);
+            await Promise.all([waitForFile(firstOutputUri), waitForFile(secondOutputUri)]);
+
+            assert.strictEqual(await readPdfPageCount(firstOutputUri), 1);
+            assert.strictEqual(await readPdfPageCount(secondOutputUri), 1);
+        } finally {
+            await deleteDirectory(directory);
+        }
+    });
+
+    test('should merge PDFs selected from the explorer into the chosen output file', async () => {
+        const directory = await createTestDirectory('merge-pdf-command');
+
+        try {
+            const firstInputUri = vscode.Uri.joinPath(directory, 'one-page.pdf');
+            const secondInputUri = vscode.Uri.joinPath(directory, 'two-pages.pdf');
+            const outputUri = vscode.Uri.joinPath(directory, 'merged.pdf');
+            const showSaveDialogStub = sinon.stub(vscode.window, 'showSaveDialog').resolves(outputUri);
+
+            await createPdf(firstInputUri, 1);
+            await createPdf(secondInputUri, 2);
+
+            await vscode.commands.executeCommand(
+                'latex-graphics-helper.mergePdf',
+                firstInputUri,
+                [firstInputUri, secondInputUri]
+            );
+
+            await waitForFile(outputUri);
+            assert.strictEqual(showSaveDialogStub.calledOnce, true);
+            assert.deepStrictEqual(showSaveDialogStub.firstCall.args[0], { filters: { PDF: ['pdf'] } });
+            assert.strictEqual(await readPdfPageCount(outputUri), 3);
+        } finally {
+            await deleteDirectory(directory);
+        }
+    });
+
+    test('should convert a PNG selected from the explorer to a PDF', async () => {
+        const directory = await createTestDirectory('convert-png-command');
+
+        try {
+            const inputUri = vscode.Uri.joinPath(directory, 'pixel.png');
+            const outputUri = vscode.Uri.joinPath(directory, 'pixel.pdf');
+
+            await createPng(inputUri);
+
+            await vscode.commands.executeCommand('latex-graphics-helper.convertPngToPdf', inputUri, [inputUri]);
+            await waitForFile(outputUri);
+
+            assert.strictEqual(await readPdfPageCount(outputUri), 1);
+        } finally {
+            await deleteDirectory(directory);
+        }
+    });
+});

--- a/src/test/e2e/helpers.ts
+++ b/src/test/e2e/helpers.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+
+import { PDFDocument, rgb } from 'pdf-lib';
+import * as vscode from 'vscode';
+
+export function getTestWorkspaceFolder(): vscode.WorkspaceFolder {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(workspaceFolder, 'Expected vscode-test to open a workspace folder');
+    return workspaceFolder;
+}
+
+export async function createTestDirectory(name: string): Promise<vscode.Uri> {
+    const workspaceFolder = getTestWorkspaceFolder();
+    const safeName = name.replace(/[^a-z0-9_-]+/gi, '-').toLowerCase();
+    const directory = vscode.Uri.joinPath(
+        workspaceFolder.uri,
+        `${safeName}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    );
+
+    await vscode.workspace.fs.createDirectory(directory);
+    return directory;
+}
+
+export async function deleteDirectory(uri: vscode.Uri): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(uri, { recursive: true, useTrash: false });
+    } catch {
+        // Best-effort cleanup for test-generated files.
+    }
+}
+
+export async function createPdf(fileUri: vscode.Uri, pageCount: number): Promise<void> {
+    const document = await PDFDocument.create();
+
+    for (let i = 0; i < pageCount; i++) {
+        const page = document.addPage([200, 100]);
+        page.drawText(`Page ${i + 1}`, {
+            x: 20,
+            y: 45,
+            size: 16,
+            color: rgb(0, 0, 0),
+        });
+    }
+
+    await vscode.workspace.fs.writeFile(fileUri, await document.save());
+}
+
+export async function createPng(fileUri: vscode.Uri): Promise<void> {
+    const pngBytes = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l0ud5AAAAABJRU5ErkJggg==',
+        'base64'
+    );
+
+    await vscode.workspace.fs.writeFile(fileUri, pngBytes);
+}
+
+export async function readPdfPageCount(fileUri: vscode.Uri): Promise<number> {
+    const bytes = await vscode.workspace.fs.readFile(fileUri);
+    const pdf = await PDFDocument.load(bytes);
+    return pdf.getPageCount();
+}
+
+export async function waitForFile(fileUri: vscode.Uri, timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            await vscode.workspace.fs.stat(fileUri);
+            return;
+        } catch {
+            await new Promise(resolve => setTimeout(resolve, 50));
+        }
+    }
+
+    assert.fail(`Timed out waiting for file: ${fileUri.fsPath}`);
+}

--- a/src/test/e2e/latex_drop_edit_provider.test.ts
+++ b/src/test/e2e/latex_drop_edit_provider.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert';
+
+import * as vscode from 'vscode';
+
+import { LatexDropEditProvider } from '../../edit_provider/latex_drop_edit_provider';
+import { createPdf, createTestDirectory, deleteDirectory } from './helpers';
+
+suite('LaTeX drop edit provider e2e Test Suite', () => {
+    suiteSetup(async () => {
+        await vscode.extensions.getExtension('naatin777.latex-graphics-helper')!.activate();
+
+        const configuration = vscode.workspace.getConfiguration('latex-graphics-helper');
+        await configuration.update('figure.placementOptions', ['[H]'], vscode.ConfigurationTarget.Workspace);
+        await configuration.update('figure.alignmentOptions', ['\\centering'], vscode.ConfigurationTarget.Workspace);
+        await configuration.update('figure.graphicsOptions', ['[width=0.8\\linewidth]'], vscode.ConfigurationTarget.Workspace);
+        await configuration.update('subfigure.verticalAlignmentOptions', ['[t]'], vscode.ConfigurationTarget.Workspace);
+        await configuration.update('subfigure.widthOptions', ['{0.45\\linewidth}'], vscode.ConfigurationTarget.Workspace);
+        await configuration.update('subfigure.spacingOptions', ['\\hfill'], vscode.ConfigurationTarget.Workspace);
+    });
+
+    test('should create a figure snippet for a dropped PDF URI', async () => {
+        const directory = await createTestDirectory('drop-single-pdf');
+
+        try {
+            const documentUri = vscode.Uri.joinPath(directory, 'main.tex');
+            const pdfUri = vscode.Uri.joinPath(directory, 'figures', 'sample.pdf');
+
+            await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(directory, 'figures'));
+            await vscode.workspace.fs.writeFile(documentUri, Buffer.from('', 'utf8'));
+            await createPdf(pdfUri, 1);
+
+            const document = await vscode.workspace.openTextDocument(documentUri);
+            const edit = await provideDropEdit(document, [pdfUri]);
+            const snippet = getSnippetValue(edit);
+
+            assert.ok(snippet.includes('\\\\begin{figure\\}'));
+            assert.ok(snippet.includes('\\\\includegraphics[width=0.8\\\\linewidth]{figures/sample.pdf\\}'));
+            assert.ok(snippet.includes('\\\\caption{${1:sample}\\}'));
+            assert.ok(snippet.includes('\\\\label{fig:${2:sample}\\}'));
+        } finally {
+            await deleteDirectory(directory);
+        }
+    });
+
+    test('should create minipage snippets for multiple dropped PDF URIs', async () => {
+        const directory = await createTestDirectory('drop-multiple-pdfs');
+
+        try {
+            const documentUri = vscode.Uri.joinPath(directory, 'main.tex');
+            const firstPdfUri = vscode.Uri.joinPath(directory, 'figures', 'first.pdf');
+            const secondPdfUri = vscode.Uri.joinPath(directory, 'figures', 'second.pdf');
+
+            await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(directory, 'figures'));
+            await vscode.workspace.fs.writeFile(documentUri, Buffer.from('', 'utf8'));
+            await createPdf(firstPdfUri, 1);
+            await createPdf(secondPdfUri, 1);
+
+            const document = await vscode.workspace.openTextDocument(documentUri);
+            const edit = await provideDropEdit(document, [firstPdfUri, secondPdfUri]);
+            const snippet = getSnippetValue(edit);
+
+            assert.strictEqual(countOccurrences(snippet, '\\\\begin{minipage\\}'), 2);
+            assert.ok(snippet.includes('\\\\includegraphics[width=0.8\\\\linewidth]{figures/first.pdf\\}'));
+            assert.ok(snippet.includes('\\\\includegraphics[width=0.8\\\\linewidth]{figures/second.pdf\\}'));
+            assert.ok(snippet.includes('\\\\hfill'));
+        } finally {
+            await deleteDirectory(directory);
+        }
+    });
+
+    test('should not provide an edit when dropped data does not contain URI list text', async () => {
+        const directory = await createTestDirectory('drop-without-uri-list');
+
+        try {
+            const documentUri = vscode.Uri.joinPath(directory, 'main.tex');
+            await vscode.workspace.fs.writeFile(documentUri, Buffer.from('', 'utf8'));
+
+            const document = await vscode.workspace.openTextDocument(documentUri);
+            const provider = new LatexDropEditProvider();
+            const dataTransfer = new vscode.DataTransfer();
+            dataTransfer.set('text/plain', new vscode.DataTransferItem('plain text'));
+
+            const tokenSource = new vscode.CancellationTokenSource();
+            try {
+                const edit = await provider.provideDocumentDropEdits(
+                    document,
+                    new vscode.Position(0, 0),
+                    dataTransfer,
+                    tokenSource.token
+                );
+
+                assert.strictEqual(edit, undefined);
+            } finally {
+                tokenSource.dispose();
+            }
+        } finally {
+            await deleteDirectory(directory);
+        }
+    });
+});
+
+async function provideDropEdit(document: vscode.TextDocument, uris: vscode.Uri[]): Promise<vscode.DocumentDropEdit> {
+    const provider = new LatexDropEditProvider();
+    const dataTransfer = new vscode.DataTransfer();
+    dataTransfer.set('text/uri-list', new vscode.DataTransferItem(uris.map(uri => uri.toString()).join('\r\n')));
+
+    const tokenSource = new vscode.CancellationTokenSource();
+    try {
+        const edit = await provider.provideDocumentDropEdits(
+            document,
+            new vscode.Position(0, 0),
+            dataTransfer,
+            tokenSource.token
+        );
+
+        assert.ok(edit, 'Expected a document drop edit');
+        assert.ok(!Array.isArray(edit), 'Expected a single document drop edit');
+        return edit;
+    } finally {
+        tokenSource.dispose();
+    }
+}
+
+function getSnippetValue(edit: vscode.DocumentDropEdit): string {
+    assert.ok(edit.insertText instanceof vscode.SnippetString, 'Expected drop edit to insert a snippet');
+    return edit.insertText.value;
+}
+
+function countOccurrences(value: string, search: string): number {
+    return value.split(search).length - 1;
+}

--- a/src/test/e2e/latex_drop_edit_provider.test.ts
+++ b/src/test/e2e/latex_drop_edit_provider.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 import { LatexDropEditProvider } from '../../edit_provider/latex_drop_edit_provider';
+
 import { createPdf, createTestDirectory, deleteDirectory } from './helpers';
 
 suite('LaTeX drop edit provider e2e Test Suite', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Configure vscode-test to open a temporary workspace for Extension Host e2e tests
- Add shared e2e helpers for generating PDFs/PNGs and waiting on command outputs
- Add e2e coverage for contributed commands and LaTeX PDF drop snippets

## Testing
- `npm run test` — 42 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfbe2744-cc50-4298-ae81-d3a8e32b8a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfbe2744-cc50-4298-ae81-d3a8e32b8a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

