### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single **VS Code extension** (`LaTeX Graphics Helper`, TypeScript). There is no server; the extension runs in-process inside VS Code and shells out to optional external CLIs for some features. Standard commands live in `package.json` `scripts` and `.github/workflows/test.yml`; only the non-obvious caveats are noted here.
+
+- **Dependencies**: `npm ci` (run automatically by the startup update script). Node 22 is expected (`engines`/CI).
+- **Build / lint**: `npm run compile` (`tsc` → `out/`) and `npm run lint` (`eslint src`). Output goes to `out/` (gitignored); `main` is `out/extension.js`.
+- **Tests need a display**: `npm test` (`vscode-test`) launches a real VS Code/Electron and fails on this headless VM without an X server. Always run it as `xvfb-run -a npm run test`. A display (`:1`) is also available if launching the GUI. The dbus/gpu `ERROR:` lines printed during the run are harmless headless warnings, not test failures.
+- **Running the extension manually**: there is no `code` binary on `PATH`. `@vscode/test-electron` downloads a full VS Code under `.vscode-test/vscode-linux-x64-<version>/` (created after running the tests once). Launch the Extension Development Host with that binary, e.g. `DISPLAY=:1 .vscode-test/vscode-linux-x64-<version>/code --no-sandbox --user-data-dir=/tmp/vscode-dev-user --extensionDevelopmentPath="$PWD" <folder-to-open>`. The version subdir changes over time, so glob it rather than hardcoding.
+- **Optional external tools (not installed)**: `pdfcrop` (crop), `pdftocairo` (PDF→image), Draw.io desktop (drawio→PDF), and Chrome/Puppeteer (SVG→PDF). The PNG/JPEG→PDF, merge, and split features use bundled npm libs (`sharp`, `pdf-lib`) and need no external binaries — use one of these for a quick end-to-end smoke test (e.g. right-click a `.png` → "Convert to PDF").
+- **Git hooks**: `lefthook.yml` runs `eslint` + `tsc --noEmit` on pre-commit. Lefthook is a devDependency; hooks only fire if installed locally (`npx lefthook install`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the **LaTeX Graphics Helper** VS Code extension on Cursor Cloud, and documents non-obvious caveats for future agents in `AGENTS.md`.

No application code was changed. The only file added is `AGENTS.md`.

## Environment

- **Update script** (startup): `npm ci`
- Node 22, npm 10; build via `tsc`, lint via `eslint`, tests via `@vscode/test-electron` (needs a headless display → `xvfb-run`).

## Verification

| Step | Command | Result |
|---|---|---|
| Install | `npm ci` | ✅ 335 packages |
| Build | `npm run compile` | ✅ |
| Lint | `npm run lint` | ✅ |
| Test | `xvfb-run -a npm run test` | ✅ 34 passing |
| Run | Extension Dev Host + "Convert PNG to PDF" | ✅ `sample.pdf` created |

### Hello-world demo

Launched the Extension Development Host, right-clicked `sample.png` → "Convert to PDF"; the extension created a valid `sample.pdf` (confirmed `PDF document, version 1.7` on disk).

[convert_png_to_pdf_demo.mp4](https://cursor.com/agents/bc-159666df-89b9-4c49-ad1a-00df27dcb330/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconvert_png_to_pdf_demo.mp4)

[Convert to PDF context menu](https://cursor.com/agents/bc-159666df-89b9-4c49-ad1a-00df27dcb330/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontext_menu_convert_to_pdf.webp)
[Explorer showing generated sample.pdf](https://cursor.com/agents/bc-159666df-89b9-4c49-ad1a-00df27dcb330/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexplorer_png_and_pdf.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159666df-89b9-4c49-ad1a-00df27dcb330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159666df-89b9-4c49-ad1a-00df27dcb330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

